### PR TITLE
Fact pkgng_supported always returns true and case sensitivity nit.

### DIFF
--- a/lib/facter/pkgng.rb
+++ b/lib/facter/pkgng.rb
@@ -15,7 +15,7 @@ Facter.add("pkgng_enabled") do
   confine :kernel => "FreeBSD"
 
   setcode do
-    if %x{/usr/bin/make -f /etc/make.conf -VWITH_PKGNG} =~ /(yes|true)/
+    if %x{/usr/bin/make -f /etc/make.conf -VWITH_PKGNG} =~ /(yes|true)/i
       "true"
     end if File.exist?('/etc/make.conf')
   end


### PR DESCRIPTION
I noticed on our 8.3 systems pkgng_supported was true. An empty array will evaluate to true. Also switched the regex for the value of WITH_PKGNG to case insensitive, Capitalized YES|TRUE is also valid in /etc/make.conf afaik.
