### PR TITLE
Fix `pkg remove`.

### DIFF
--- a/lib/puppet/provider/package/pkgng.rb
+++ b/lib/puppet/provider/package/pkgng.rb
@@ -32,7 +32,7 @@ Puppet::Type.type(:package).provide :pkgng, :parent => Puppet::Provider::Package
   end
 
   def uninstall
-    cmd = ['remove', @resource[:name]]
+    cmd = ['remove', '-qy', @resource[:name]]
     pkg(*cmd)
   end
 


### PR DESCRIPTION
A '-y' flag is required for non-interactive removal of packages.  The
'-q' flag is also provided for consistency with `pkg install` flags.
