### PR TITLE
set the fact "pkgng_supported" to "true" for FreeBSD 9.x and 10.x

### DIFF
--- a/lib/facter/pkgng.rb
+++ b/lib/facter/pkgng.rb
@@ -4,7 +4,7 @@ Facter.add("pkgng_supported") do
 
   setcode do
     kernel = Facter.value('kernelversion')
-    if kernel =~ /^(9|10)/
+    if kernel =~ /^(9|10)(\.[0-9])?/
       "true"
     end
   end


### PR DESCRIPTION
Just a small regex modification. With the original one, FreeBSD 9.2 wasn't supported.
