### PR TITLE
Update URL for FreeBSD pkg repositories.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -16,7 +16,7 @@ class pkgng (
   # At the time of this writing, only FreeBSD 9 and 10 are supported by pkgng
   if $pkgng_supported {
     file { "/usr/local/etc/pkg.conf":
-      content  => "PACKAGESITE: ${packagesite}",
+      content  => "PACKAGESITE: ${packagesite}\n",
       notify   => Exec['pkg update'],
     }
 

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,5 +1,5 @@
 class pkgng::params {
-  $packagesite  = inline_template("http://pkgbeta.freebsd.org/freebsd:<%= @kernelversion.split('.').first %>:${architecture}/latest/")
+  $packagesite  = 'http://pkg.FreeBSD.org/${ABI}/latest'
   $srv_mirrors  = 'NO'
   $pkg_dbdir    = '/var/db/pkg'
   $pkg_cachedir = '/var/cache/pkg'


### PR DESCRIPTION
Note that ${ABI} should go literally in the file and is not intended
to be expanded by Puppet, thus the single quotes.

I've also added a newline to the end of the line in the configuration
file.
