### PR TITLE
Improve pkg detection.

### DIFF
--- a/lib/facter/pkgng.rb
+++ b/lib/facter/pkgng.rb
@@ -15,9 +15,9 @@ Facter.add("pkgng_enabled") do
   confine :kernel => "FreeBSD"
 
   setcode do
-    if %x{/usr/bin/make -f /etc/make.conf -VWITH_PKGNG} =~ /(yes|true)/i
+    if system("TMPDIR=/dev/null ASSUME_ALWAYS_YES=1 PACKAGESITE=file:///nonexistent pkg info pkg >/dev/null 2>&1")
       "true"
-    end if File.exist?('/etc/make.conf')
+    end
   end
 
 end


### PR DESCRIPTION
This is based on the section in the pkg manpage:

  The following script is the safest way to detect if pkg is installed
  and activated:

```
if TMPDIR=/dev/null ASSUME_ALWAYS_YES=1 \
     PACKAGESITE=file:///nonexistent \
     pkg info pkg >/dev/null 2>&1; then
  # pkgng-specifics
else
  # pkg_install-specifics
fi
```

This fits my workload better.
