### PR TITLE
Only get version if pkgng is installed

### DIFF
--- a/lib/facter/pkgng.rb
+++ b/lib/facter/pkgng.rb
@@ -26,7 +26,9 @@ Facter.add("pkgng_version") do
   confine :kernel => "FreeBSD"
 
   setcode do
-    Facter::Util::Resolution.exec("pkg query %v pkg 2>/dev/null")
+    if Facter.pkgng_enabled
+      Facter::Util::Resolution.exec("pkg query %v pkg 2>/dev/null")
+    end
   end
 
 end


### PR DESCRIPTION
A small fix to the fact to only get the pkgng version if it actually installed.

Else the fact wil "lock up"  on systems that have a " Do you want to install?"  pkg binary
