### PR TITLE
Purge default repos if specified (new default)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,17 +19,30 @@ The easiest way to install is to install from the forge.
 puppet module install zleslie/pkgng
 ```
 
-Then to configure your system to use a PkgNG, a simple include will do.
+Then to configure your system to use PkgNG with all default settings, a
+simple include will do.
 
 ```Puppet
 include pkgng
 ```
 
+You may wish to override settings though, to do this simply use it as a class:
+
+```Puppet
+class { 'pkgng':
+  purge_repos_d => false
+}
+```
+
+By default, this module will erase the default repository and you'll want to
+define some. To disable this behaviour you can use the example above of
+setting `purge_repos_d` to false.
+
 Using specific repositories is as simple as a Puppet resource.
 
 ```Puppet
-pkgng::repo { 'pkg.freebsd.org': }
-pkgng::repo { 'my.own.repo': }
+pkgng::repo { 'pkg.freebsd.org': }  # You'll want this one!
+pkgng::repo { 'my.own.repo': }      # You can then specify more...
 ```
 
 ### Installation via [R10K](https://github.com/adrienthebo/r10k)

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -2,14 +2,18 @@
 # support for managing packages with Puppet.  This will eventually be in
 # mainline FreeBSD, but for now, we are leaving the installation up to the
 # adminstrator, since there is no going back.
+#
+# If you have purge_repos_d as true - then you'll have no repositories
+# defined unless you define one. You want to do this as you'll want this
+# module to control repos anyway.
+#
 # To install PkgNG, one can simply run the following:
 # make -C /usr/ports/ports-mgmg/pkg install clean
-
 class pkgng (
   $pkg_dbdir     = $pkgng::params::pkg_dbdir,
   $pkg_cachedir  = $pkgng::params::pkg_cachedir,
   $portsdir      = $pkgng::params::portsdir,
-  $purge_repos_d = false,
+  $purge_repos_d = true,
   $repos         = {},
 ) inherits pkgng::params {
 
@@ -35,6 +39,13 @@ class pkgng (
     File['/usr/local/etc/pkg/repos'] {
       recurse => true,
       purge   => true,
+    }
+
+    file { '/etc/pkg':
+      ensure  => directory,
+      purge   => true,
+      recurse => true,
+      before  => Exec['pkg update']
     }
   }
 


### PR DESCRIPTION
With regards to #27 this makes puppet-pkgng go ahead and purge /etc/pkg if authoritative is true. This seems a sensible default to be true as noted in the issue by the @xaque208.

It's fine like that as you can simply specify a repo and you're good to go anyway.
