### PR TITLE
Fix method call for Facter v2

### DIFF
--- a/lib/facter/pkgng.rb
+++ b/lib/facter/pkgng.rb
@@ -26,7 +26,7 @@ Facter.add("pkgng_version") do
   confine :kernel => "FreeBSD"
 
   setcode do
-    if Facter.pkgng_enabled
+    if Facter.value('pkgng_enabled') == "true"
       Facter::Util::Resolution.exec("pkg query %v pkg 2>/dev/null")
     end
   end


### PR DESCRIPTION
Facter 2 doesn't seem to support methods for fact values.  This code
moves to use a supported method that can be used to retrieve fact values
from the loaded facts.
