### PR TITLE
Fixes facts for when pkg was not installed by pkg.

### DIFF
--- a/lib/facter/pkgng.rb
+++ b/lib/facter/pkgng.rb
@@ -33,7 +33,9 @@ Facter.add("pkgng_version") do
   confine :kernel => "FreeBSD"
 
   setcode do
-    Facter::Util::Resolution.exec("pkg -v 2>/dev/null")
+    if Facter.value('pkgng_enabled') == "true"
+      Facter::Util::Resolution.exec("pkg -v 2>/dev/null")
+    end
   end
 
 end


### PR DESCRIPTION
Pkg may be installed via make or pkg_add. There is also a bug I am
trying to run down where pkg bootstraps fine but still isn't present in
`pkg info`.

This change fixes puppet facts for FBSD 10 or 11 in any of the
aforementioned cases. I did not touch FBSD 8 or 9, due to the warning
present in the pkg(8) description of the -N option.

See also: https://gist.github.com/rmelcer/6e863663e0ea4815e260
