### PR TITLE
Add support for DragonFly

### DIFF
--- a/lib/facter/pkgng.rb
+++ b/lib/facter/pkgng.rb
@@ -1,18 +1,26 @@
 
 Facter.add("pkgng_supported") do
-  confine :kernel => "FreeBSD"
+  confine :kernel => ["FreeBSD", "DragonFly"]
 
   setcode do
+    os = Facter.value('kernel')
     kernel = Facter.value('kernelversion')
-    if kernel =~ /^(8|9|10|11)(\.[0-9])?/
-      "true"
+    if os == "FreeBSD"
+      if kernel =~ /^(8|9|10|11)(\.[0-9])?/
+        "true"
+      end
+    elsif os == "DragonFly"
+      maj, min = kernel.split('.').map { |s| s.to_i }
+      if maj > 3 or (maj == 3 and min >= 4)
+        "true"
+      end
     end
   end
 
 end
 
 Facter.add("pkgng_enabled") do
-  confine :kernel => "FreeBSD"
+  confine :kernel => ["FreeBSD", "DragonFly"]
 
   setcode do
     if system("TMPDIR=/dev/null ASSUME_ALWAYS_YES=1 PACKAGESITE=file:///nonexistent pkg info pkg >/dev/null 2>&1")
@@ -23,7 +31,7 @@ Facter.add("pkgng_enabled") do
 end
 
 Facter.add("pkgng_version") do
-  confine :kernel => "FreeBSD"
+  confine :kernel => ["FreeBSD", "DragonFly"]
 
   setcode do
     if Facter.value('pkgng_enabled') == "true"

--- a/lib/puppet/provider/package/pkgng.rb
+++ b/lib/puppet/provider/package/pkgng.rb
@@ -1,11 +1,11 @@
 require 'puppet/provider/package'
 
 Puppet::Type.type(:package).provide :pkgng, :parent => Puppet::Provider::Package do
-  desc "A PkgNG provider for FreeBSD."
+  desc "A PkgNG provider for FreeBSD and DragonFly."
 
   commands :pkg => "/usr/local/sbin/pkg"
 
-  confine :operatingsystem => :freebsd
+  confine :operatingsystem => [:freebsd, :dragonfly]
   confine :pkgng_enabled => :true
   
   defaultfor :operatingsystem => :freebsd


### PR DESCRIPTION
DragonFly BSD also uses pkgng nowadays. It'd be great if support for it could be merged into your puppet-pkgng module.

Thanks,
Alex
