### PR TITLE
version depend on enable not working

### DIFF
--- a/lib/facter/pkgng.rb
+++ b/lib/facter/pkgng.rb
@@ -41,7 +41,7 @@ Facter.add("pkgng_version") do
   confine :kernel => ["FreeBSD", "DragonFly"]
 
   setcode do
-    if Facter.value('pkgng_enabled') == "true"
+    if system("TMPDIR=/dev/null ASSUME_ALWAYS_YES=1 PACKAGESITE=file:///nonexistent pkg info pkg >/dev/null 2>&1")
       Facter::Util::Resolution.exec("pkg -v 2>/dev/null")
     end
   end


### PR DESCRIPTION
In a FreeBSD 10.0-RELEASE jail with puppet 3.6.2_1 I would get the following error when using this module:

```
Could not retrieve fact='pkgng_version', resolution='<anonymous>': undefined method `pkgng_enabled' for Facter:Module
Could not retrieve fact='pkgng_version', resolution='<anonymous>': undefined method `pkgng_enabled' for Facter:Module
Could not retrieve fact='pkgng_version', resolution='<anonymous>': undefined method `pkgng_enabled' for Facter:Module
Error: Could not retrieve catalog from remote server: Error 400 on SERVER: PKGng is either not supported on your system or it is too old at /usr/local/etc/puppet/modules/pkgng/manifests/init.pp:18
```

Using the same check as is used to determine pkgng_enabled works fine for me.
