### PR TITLE
Drop Puppet 4 support

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -19,7 +19,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.1.0 < 7.0.0"
+      "version_requirement": ">= 5.5.8 < 7.0.0"
     }
   ],
   "dependencies": [


### PR DESCRIPTION
aed5b598642402653aef63922ca5d4fc4853df5f stopped testing on Puppet 4, this also drops it from metadata.json.

Included in https://github.com/voxpupuli/puppet-pkgng/pull/106 but here for the changelog.